### PR TITLE
Added InitialCondition and MeshBlock classes.

### DIFF
--- a/src/fvm_2d_cart/mesh/mesh_block/mesh_block.cpp
+++ b/src/fvm_2d_cart/mesh/mesh_block/mesh_block.cpp
@@ -1,0 +1,261 @@
+#ifndef __MESH_BLOCK_CPP
+#define __MESH_BLOCK_CPP
+
+#include "mesh_block.h"
+
+namespace HyperFlow {
+
+/* Constructor */
+MeshBlock::MeshBlock()
+{}
+
+/* Constructor from number of cells */
+MeshBlock::MeshBlock(const Vec1D& _extents,
+                     const unsigned int _x_cells,
+                     const unsigned int _y_cells,
+                     const unsigned int _ghost_cells,
+                     const unsigned int _dimension)
+:
+    extents(_extents),
+    x_cells(_x_cells),
+    y_cells(_y_cells),
+    ghost_cells(_ghost_cells),
+    dimension(_dimension)
+{
+    /* Each edge gains a collection of ghost cells for
+     * boundary handling */
+    total_x_cells = x_cells + 2 * ghost_cells;
+    total_y_cells = y_cells + 2 * ghost_cells;
+
+    /* Set the constant step sizes in each direction */
+    dx = calculate_dx();
+    dy = calculate_dy();
+
+    /* Initialise the fields storage array */
+    fields = Vec3D(total_x_cells, Vec2D(total_y_cells, Vec1D(dimension)));
+
+    /* Initialise and calculate the centroid coordinates storage array */
+    centroids = Vec3D(total_x_cells, Vec2D(total_y_cells, Vec1D(2)));
+    calculate_centroids();
+}
+
+/* Destructor */
+MeshBlock::~MeshBlock()
+{}
+
+/* Obtain a vector of the field values at a particular index */
+Vec1D& MeshBlock::operator() (const unsigned int x_index,
+                              const unsigned int y_index)
+{
+    return fields[x_index][y_index];
+}
+
+
+/* Flow value write access */
+void MeshBlock::set_flow_values(const unsigned int x_index,
+                                const unsigned int y_index,
+                                const Vec1D& _flow_values)
+{
+    fields[x_index][y_index] = _flow_values;
+}
+
+/* Flow value read access */
+const Vec1D& MeshBlock::get_flow_values(const unsigned int x_index,
+                                        const unsigned int y_index) const
+{
+    return fields[x_index][y_index];
+}
+
+/* Read access to the number of x cells */
+const unsigned int MeshBlock::get_x_cells() const
+{
+    return x_cells;
+}
+
+/* Read access to the number of y cells */
+const unsigned int MeshBlock::get_y_cells() const
+{
+    return y_cells;
+}
+
+/* Read access to the number of ghost cells on each edge */
+const unsigned int MeshBlock::get_ghost_cells() const
+{
+    return ghost_cells;
+}
+
+/* Read access to the total number of cells in the x direction */
+const unsigned int MeshBlock::get_total_x_cells() const
+{
+    return total_x_cells;
+}
+
+/* Read access to the total number of cells in the y direction */
+const unsigned int MeshBlock::get_total_y_cells() const
+{
+    return total_y_cells;
+}
+
+/* Read access to the dimension of the model system */
+const unsigned int MeshBlock::get_dimension() const
+{
+    return dimension;
+}
+
+/* Read access to the x-direction step size */
+const double MeshBlock::get_dx() const
+{
+    return dx;
+}
+
+/* Read access to the y-direction step size */
+const double MeshBlock::get_dy() const
+{
+    return dy;
+}
+
+/* Read access to left side x-coordinate */
+const double MeshBlock::get_x_left() const
+{
+    return extents[0];
+}
+
+/* Read access to right side x-coordinate */
+const double MeshBlock::get_x_right() const
+{
+    return extents[1];
+}
+
+/* Read access to bottom side y-coordinate */
+const double MeshBlock::get_y_bottom() const
+{
+    return extents[2];
+}
+
+/* Read access to top side y-coordinate */
+const double MeshBlock::get_y_top() const
+{
+    return extents[3];
+}
+
+/* Read access to centroids */
+const Vec3D& MeshBlock::get_centroids() const
+{
+    return centroids;
+}
+
+/* Calculation of centroid for a cell index */
+const Vec1D& MeshBlock::get_centroid(const unsigned int x_index,
+                                     const unsigned int y_index) const
+{
+    return centroids[x_index][y_index];
+}
+
+/* Write access to entire flow fields */
+void MeshBlock::set_fields(const Vec3D& _fields)
+{
+    fields = _fields;
+}
+
+/* Read access to entire flow fields */
+const Vec3D& MeshBlock::get_fields() const
+{
+    return fields;
+}
+
+/* Backward difference in the x-direction */
+Vec1D MeshBlock::delta_x_back(const unsigned int x_index,
+                              const unsigned int y_index)
+{
+    Vec1D delta = fields[x_index][y_index] - fields[x_index - 1][y_index];
+    return delta;
+}
+
+/* Forward difference in the x-direction */
+Vec1D MeshBlock::delta_x_forward(const unsigned int x_index,
+                                 const unsigned int y_index)
+{
+    Vec1D delta = fields[x_index + 1][y_index] - fields[x_index][y_index];
+    return delta;
+}
+
+/* Central difference in the x-direction */
+Vec1D MeshBlock::delta_x_central(const unsigned int x_index,
+                                 const unsigned int y_index)
+{
+    Vec1D delta = fields[x_index + 1][y_index] - fields[x_index - 1][y_index];
+    return delta;
+}
+
+/* Backward difference in the y-direction */
+Vec1D MeshBlock::delta_y_back(const unsigned int x_index,
+                              const unsigned int y_index)
+{
+    Vec1D delta = fields[x_index][y_index] - fields[x_index][y_index - 1];
+    return delta;
+}
+
+/* Forward difference in the y-direction */
+Vec1D MeshBlock::delta_y_forward(const unsigned int x_index,
+                                 const unsigned int y_index)
+{
+    Vec1D delta = fields[x_index][y_index + 1] - fields[x_index][y_index];
+    return delta;
+}
+
+/* Central difference in the y-direction */
+Vec1D MeshBlock::delta_y_central(const unsigned int x_index,
+                                 const unsigned int y_index)
+{
+    Vec1D delta = fields[x_index][y_index + 1] - fields[x_index][y_index - 1];
+    return delta;
+}
+
+/* Initialise field values */
+void MeshBlock::initialise_field_values(const std::shared_ptr<InitialCondition>& init_con)
+{
+    for (unsigned int i=ghost_cells; i<total_x_cells - ghost_cells; i++) {
+        for (unsigned int j=ghost_cells; j<total_y_cells - ghost_cells; j++) {
+            Vec1D init_flow_values = init_con->operator()(centroids[i][j][0],
+                                                          centroids[i][j][1]);
+            set_flow_values(i, j, init_flow_values);;
+        }
+    }
+}
+
+/* Calculate the x-direction step size */
+double MeshBlock::calculate_dx()
+{
+    return (get_x_right() - get_x_left()) / x_cells;
+}
+
+/* Calculate the y-direction step size */
+double MeshBlock::calculate_dy()
+{
+    return (get_y_top() - get_y_bottom()) / y_cells;
+}
+
+/* Calculate the cell centroid coordinates */
+void MeshBlock::calculate_centroids() {
+    double coord_start_x = get_x_left() - (static_cast<double>(ghost_cells) - 0.5) * dx;
+    double coord_start_y = get_y_bottom() - (static_cast<double>(ghost_cells) - 0.5) * dy;
+
+    for (unsigned int i=0; i<total_x_cells; i++) {
+        for (unsigned int j=0; j<total_y_cells; j++) {
+            if (
+                (i > ghost_cells - 1) && (i < total_x_cells - ghost_cells) &&
+                (j > ghost_cells - 1) && (j < total_y_cells - ghost_cells)
+            ) {
+                centroids[i][j][0] = coord_start_x + static_cast<double>(i) * dx;
+                centroids[i][j][1] = coord_start_y + static_cast<double>(j) * dy;
+            } else {
+                centroids[i][j][0] = 0.0;
+                centroids[i][j][1] = 0.0;
+            }
+        }
+    }
+}
+
+}
+
+#endif

--- a/src/fvm_2d_cart/mesh/mesh_block/mesh_block.h
+++ b/src/fvm_2d_cart/mesh/mesh_block/mesh_block.h
@@ -1,0 +1,168 @@
+#ifndef __MESH_BLOCK_H
+#define __MESH_BLOCK_H
+
+#include "../../tensor/tensor.h"
+#include "../../simulation/initcon/initcon/initcon.h"
+
+namespace HyperFlow {
+
+class MeshBlock {
+
+    public:
+
+        /* Constructor */
+        MeshBlock();
+
+        /* Constructor from number of cells */
+        MeshBlock(const Vec1D& _extents,
+                  const unsigned int _x_cells,
+                  const unsigned int _y_cells,
+                  const unsigned int _ghost_cells,
+                  const unsigned int _dimension);
+
+        /* Destructor */
+        virtual ~MeshBlock();
+
+        /* Obtain a vector of the field values at a particular index */
+        Vec1D& operator() (const unsigned int x_index,
+                           const unsigned int y_index);
+
+        /* Flow value write access */
+        void set_flow_values(const unsigned int x_index,
+                             const unsigned int y_index,
+                             const Vec1D& _flow_values);
+
+        /* Flow value read access */
+        const Vec1D& get_flow_values(const unsigned int x_index,
+                                     const unsigned int y_index) const;
+
+        /* Read access to the number of x cells */
+        const unsigned int get_x_cells() const;
+
+        /* Read access to the number of y cells */
+        const unsigned int get_y_cells() const;
+
+        /* Read access to the number of ghost cells on each edge */
+        const unsigned int get_ghost_cells() const;
+
+        /* Read access to the total number of cells in the x direction */
+        const unsigned int get_total_x_cells() const;
+
+        /* Read access to the total number of cells in the y direction */
+        const unsigned int get_total_y_cells() const;
+
+        /* Read access to the dimension of the model system */
+        const unsigned int get_dimension() const;
+
+        /* Read access to the x-direction step size */
+        const double get_dx() const;
+
+        /* Read access to the y-direction step size */
+        const double get_dy() const;
+
+        /* Read access to left side x-coordinate */
+        const double get_x_left() const;
+
+        /* Read access to right side x-coordinate */
+        const double get_x_right() const;
+
+        /* Read access to bottom side y-coordinate */
+        const double get_y_bottom() const;
+
+        /* Read access to top side y-coordinate */
+        const double get_y_top() const;
+
+        /* Write access to entire flow fields */
+        void set_fields(const Vec3D& _fields);
+
+        /* Read access to entire flow fields */
+        const Vec3D& get_fields() const;
+
+        /* Read access to centroid coordinates storage array */
+        const Vec3D& get_centroids() const;
+
+        /* Read access to centroid coordinates at cell index */
+        const Vec1D& get_centroid(const unsigned int x_index,
+                                  const unsigned int y_index) const;
+
+        /* Backward difference in the x-direction */
+        Vec1D delta_x_back(const unsigned int x_index,
+                           const unsigned int y_index);
+
+        /* Forward difference in the x-direction */
+        Vec1D delta_x_forward(const unsigned int x_index,
+                              const unsigned int y_index);
+
+
+        /* Central difference in the x-direction */
+        Vec1D delta_x_central(const unsigned int x_index,
+                              const unsigned int y_index);
+
+
+        /* Backward difference in the y-direction */
+        Vec1D delta_y_back(const unsigned int x_index,
+                           const unsigned int y_index);
+
+
+        /* Forward difference in the y-direction */
+        Vec1D delta_y_forward(const unsigned int x_index,
+                              const unsigned int y_index);
+
+
+        /* Central difference in the y-direction */
+        Vec1D delta_y_central(const unsigned int x_index,
+                              const unsigned int y_index);
+
+        /* Initialise field values */
+        void initialise_field_values(const std::shared_ptr<InitialCondition>& init_con);
+
+    private:
+
+        /* Vector containing extents of the rectangular domain:
+         * [0] - x_left, [1] - x_right, [2] - y_bottom, [3] - y_top */
+        Vec1D extents;
+
+        /* Number of non ghost cells in x-direction */
+        unsigned int x_cells;
+
+        /* Number of non ghost cells in y-direction */
+        unsigned int y_cells;
+
+        /* Number of ghost cells for each edge */
+        unsigned int ghost_cells;
+
+        /* Dimension of the model system */
+        unsigned int dimension;
+
+        /* Total cells (including ghost cells) in the x-direction */
+        unsigned int total_x_cells;
+
+        /* Total cells (including ghost cells) in the y-direciton */
+        unsigned int total_y_cells;
+
+        /* Homogeneous step-size in x-direction */
+        double dx;
+
+        /* Homogeneous step-size in y-direction */
+        double dy;
+
+        /* Multidimensional array storing flow values for mesh block */
+        Vec3D fields;
+
+        /* Coordinates of cell centroids */
+        Vec3D centroids;
+
+        /* Calculate the x-direction step size */
+        double calculate_dx();
+
+        /* Calculate the y-direction step size */
+        double calculate_dy();
+
+        /* Calculate the cell centroid coordinates */
+        void calculate_centroids();
+
+};
+
+}
+
+#endif

--- a/src/fvm_2d_cart/simulation/initcon/initcon/initcon.cpp
+++ b/src/fvm_2d_cart/simulation/initcon/initcon/initcon.cpp
@@ -1,0 +1,75 @@
+#ifndef __INITCON_CPP
+#define __INITCON_CPP
+
+#include "initcon.h"
+
+namespace HyperFlow {
+
+/* Constructor */
+InitialCondition::InitialCondition()
+{}
+
+/* Constructor from spatial and temporal extents */
+InitialCondition::InitialCondition(const double _x_left,
+                                   const double _x_right,
+                                   const double _y_bottom,
+                                   const double _y_top,
+                                   const unsigned int _dimension)
+:
+    x_left(_x_left),
+    x_right(_x_right),
+    y_bottom(_y_bottom),
+    y_top(_y_top),
+    dimension(_dimension)
+{}
+
+/* Destructor */
+InitialCondition::~InitialCondition()
+{}
+
+/* Obtain the initial flow values at the
+ * provided coordinates */
+Vec1D InitialCondition::operator() (const double x, const double y)
+{
+    Vec1D func_vals;
+
+    for (unsigned int dim=0; dim<dimension; dim++) {
+        func_vals.push_back(field_func_dim(dim)(x, y));
+    }
+    
+    return func_vals;
+}
+
+/* Obtain the left extent of the simulation */
+double InitialCondition::get_x_left()
+{
+    return x_left;
+}
+
+/* Obtain the right extent of the simulation */
+double InitialCondition::get_x_right()
+{
+    return x_right;
+}
+
+/* Obtain the bottom extent of the simulation */
+double InitialCondition::get_y_bottom()
+{
+    return y_bottom;
+}
+
+/* Obtain the top extent of the simulation */
+double InitialCondition::get_y_top()
+{
+    return y_top;
+}
+
+/* Obtain the dimensionality of the model system */ 
+unsigned int InitialCondition::get_dimension()
+{
+    return dimension;
+}
+
+}
+
+#endif

--- a/src/fvm_2d_cart/simulation/initcon/initcon/initcon.h
+++ b/src/fvm_2d_cart/simulation/initcon/initcon/initcon.h
@@ -1,0 +1,71 @@
+#ifndef __INITCON_H
+#define __INITCON_H
+
+#include <functional>
+#include <memory>
+
+#include "../../../tensor/tensor.h"
+
+namespace HyperFlow {
+
+class InitialCondition
+{
+
+    public:
+       
+        /* Constructor */
+        InitialCondition();
+        
+        /* Constructor from spatial extents */
+        InitialCondition(const double _x_left,
+                         const double _x_right,
+                         const double _y_bottom,
+                         const double _y_top,
+                         const unsigned int _dimension);
+            
+        /* Destructor */
+        virtual ~InitialCondition();
+
+        /* Obtain the initial flow values at the
+         * provided coordinates */
+        virtual Vec1D operator() (const double x, const double y);
+        
+        /* Obtain the left extent of the simulation */
+        virtual double get_x_left();
+        
+        /* Obtain the right extent of the simultion */
+        virtual double get_x_right();
+        
+        /* Obtain the bottom extent of the simulation */
+        virtual double get_y_bottom();
+        
+        /* Obtain the top extent of the simulation */
+        virtual double get_y_top();
+        
+        /* Obtain the dimensionality of the model system */
+        virtual unsigned int get_dimension();
+
+    protected:
+        
+        /* Left extent of the simulation */
+        double x_left;
+        
+        /* Right extent of the simulation */
+        double x_right;
+        
+        /* Bottom extent of the simulation */
+        double y_bottom;
+        
+        /* Top extent of the simulation */
+        double y_top;
+        
+        /* Dimensionality of the model system */
+        unsigned int dimension;
+
+        /* Return the flow value function at a particular dimension */
+        virtual std::function<double (const double, const double)> field_func_dim(const unsigned int dim) = 0;
+};
+
+}
+
+# endif


### PR DESCRIPTION
**Overview**

This PR adds two classes. The first is ``InitialCondition``, which is an abstract base class for declaring various spatial initial conditions for the simulation. The second is ``MeshBlock``, used as a constituent for the forthcoming ``Mesh`` class.