### PR TITLE
Added Godunov first-order upwind scheme classes

### DIFF
--- a/src/fvm_2d_cart/mesh/mesh/mesh.cpp
+++ b/src/fvm_2d_cart/mesh/mesh/mesh.cpp
@@ -1,0 +1,51 @@
+#ifndef __MESH_CPP
+#define __MESH_CPP
+
+#include "mesh.h"
+
+namespace HyperFlow {
+
+/* Constructor */
+Mesh::Mesh()
+{}
+
+/* Constructor from number of cells */
+Mesh::Mesh(const std::vector<std::shared_ptr<MeshBlock> >& _mesh_blocks,
+           const std::vector<std::vector<std::shared_ptr<BoundaryCondition> > >& _block_bcs)
+:
+    mesh_blocks(_mesh_blocks),
+    block_bcs(_block_bcs)
+{}
+
+/* Destructor */
+Mesh::~Mesh()
+{}
+
+/* Obtain write access to the mesh blocks */
+std::vector<std::shared_ptr<MeshBlock> >& Mesh::get_mesh_blocks()
+{
+	return mesh_blocks;
+}
+
+/* Apply boundary conditions to the individual mesh blocks */
+void Mesh::apply_bcs()
+{
+    for (unsigned int block_idx=0; block_idx<block_bcs.size(); block_idx++) {
+        block_bcs[block_idx][0]->apply_bottom();
+        block_bcs[block_idx][1]->apply_right();
+        block_bcs[block_idx][2]->apply_top();
+        block_bcs[block_idx][3]->apply_left();
+    }
+}
+
+/* Initialise field values */
+void Mesh::initialise_field_values(const std::shared_ptr<InitialCondition>& init_con)
+{
+    for (unsigned int block_idx=0; block_idx<mesh_blocks.size(); block_idx++) {
+    	mesh_blocks[block_idx]->initialise_field_values(init_con);
+    }
+}
+
+}
+
+#endif

--- a/src/fvm_2d_cart/mesh/mesh/mesh.h
+++ b/src/fvm_2d_cart/mesh/mesh/mesh.h
@@ -1,0 +1,48 @@
+#ifndef __MESH_H
+#define __MESH_H
+
+#include "../../tensor/tensor.h"
+#include "../../simulation/initcon/initcon/initcon.h"
+#include "../../scheme/boundary/boundary/boundary.h"
+#include "../mesh_block/mesh_block.h"
+
+namespace HyperFlow {
+
+class Mesh {
+
+    public:
+
+        /* Constructor */
+        Mesh();
+
+        /* Constructor from number of cells */
+        Mesh(const std::vector<std::shared_ptr<MeshBlock> >& _mesh_blocks,
+        	 const std::vector<std::vector<std::shared_ptr<BoundaryCondition> > >& _block_bcs);
+
+        /* Destructor */
+        virtual ~Mesh();
+
+        /* Obtain write access to the mesh blocks */
+        std::vector<std::shared_ptr<MeshBlock> >& get_mesh_blocks();
+
+        /* Apply boundary conditions to the individual mesh blocks */
+        void apply_bcs();
+
+        /* Initialise field values */
+        void initialise_field_values(const std::shared_ptr<InitialCondition>& init_con);
+
+    private:
+
+    	/* Collection of the mesh blocks making up the overall mesh */
+    	std::vector<std::shared_ptr<MeshBlock> > mesh_blocks;
+        
+    	/* Two-dimensional vector of boundary conditions. Outer dimension 
+    	 * is the size of number of meshes. Inner dimension represents 
+    	 * bottom, right, top and left boundaries for each block. */
+		std::vector<std::vector<std::shared_ptr<BoundaryCondition> > > block_bcs;
+
+};
+
+}
+
+#endif

--- a/src/fvm_2d_cart/scheme/godunov/godunov.cpp
+++ b/src/fvm_2d_cart/scheme/godunov/godunov.cpp
@@ -1,0 +1,122 @@
+#ifndef __GODUNOV_CPP
+#define __GODUNOV_CPP
+
+#include "godunov.h"
+
+namespace HyperFlow {
+
+/* Constructor */
+GodunovScheme::GodunovScheme()
+{}
+
+/* Constructor with model equations, Riemann solver, time-step */
+GodunovScheme::GodunovScheme(const std::shared_ptr<Model>& _model,
+                             const std::shared_ptr<RiemannSolver>& _riemann,
+                             const std::shared_ptr<TimeStep>& _timestep)
+:
+    model(_model),
+    riemann(_riemann),
+    timestep(_timestep)
+{}
+
+/* Destructor */
+GodunovScheme::~GodunovScheme()
+{}
+
+/* Carry out the Godunov scheme on the provided mesh */
+Vec3D GodunovScheme::operator() (const std::shared_ptr<MeshBlock>& mesh_block)
+{
+    Vec3D x_fluxes = calculate_fluxes_x(mesh_block);
+    Vec3D y_fluxes = calculate_fluxes_y(mesh_block);
+    Vec3D spatial_update = calculate_spatial_update(mesh_block, x_fluxes, y_fluxes);
+    return spatial_update; 
+}
+
+/* Calculate the time step via the CFL condition */
+double GodunovScheme::calculate_time_step(const std::shared_ptr<Mesh>& mesh)
+{
+    return timestep->operator()(mesh);
+}
+
+/* Number of ghost cells associated with the scheme */
+const unsigned int GodunovScheme::ghost_cells = 1;
+
+/* Calculate the fluxes in the x-direction */
+Vec3D GodunovScheme::calculate_fluxes_x(const std::shared_ptr<MeshBlock>& mesh_block)
+{
+    unsigned int x_cells = mesh_block->get_x_cells();
+    unsigned int total_y_cells = mesh_block->get_total_y_cells();
+    unsigned int dimension = mesh_block->get_dimension();
+  
+    Vec3D x_fluxes(x_cells + 1, Vec2D(total_y_cells, Vec1D(dimension, 0.0)));
+
+    for (unsigned int i=0; i<x_cells + 1; i++) {
+        for (unsigned int j=0; j<total_y_cells; j++) {
+            Vec1D rs_flux = riemann->operator()(
+                mesh_block->get_flow_values(i, j),
+                mesh_block->get_flow_values(i+1, j),
+                Direction::x
+            );
+
+            x_fluxes[i][j] = rs_flux;
+        }
+    }
+   
+    return x_fluxes;
+}
+
+/* Calculate the fluxes in the y-direction */
+Vec3D GodunovScheme::calculate_fluxes_y(const std::shared_ptr<MeshBlock>& mesh_block)
+{
+    unsigned int total_x_cells = mesh_block->get_total_x_cells();
+    unsigned int y_cells = mesh_block->get_y_cells();
+    unsigned int dimension = mesh_block->get_dimension();
+   
+    Vec3D y_fluxes(total_x_cells, Vec2D(y_cells + 1, Vec1D(dimension, 0.0)));
+    
+    for (unsigned int i=0; i<total_x_cells; i++) {
+        for (unsigned int j=0; j<y_cells + 1; j++) {
+            Vec1D rs_flux = riemann->operator()(
+                mesh_block->get_flow_values(i, j),
+                mesh_block->get_flow_values(i, j+1),
+                Direction::y
+            );
+
+            y_fluxes[i][j] = rs_flux;
+        }
+    }
+   
+    return y_fluxes;
+}
+
+/* Calculate the spatial update via the fluxes */
+Vec3D GodunovScheme::calculate_spatial_update(const std::shared_ptr<MeshBlock>& mesh_block,
+                                              const Vec3D& x_fluxes,
+                                              const Vec3D& y_fluxes)
+{
+    double one_dx = 1.0 / mesh_block->get_dx();
+    double one_dy = 1.0 / mesh_block->get_dy();
+
+    unsigned int total_x_cells = mesh_block->get_total_x_cells();
+    unsigned int total_y_cells = mesh_block->get_total_y_cells();
+    unsigned int dimension = mesh_block->get_dimension();
+
+    Vec3D fields_update(total_x_cells, Vec2D(total_y_cells, Vec1D(dimension, 0.0)));
+
+    for (unsigned int i=1; i<total_x_cells - 1; i++) {
+        for (unsigned int j=1; j<total_y_cells - 1; j++) {
+            Vec1D cell_update = (
+                (one_dx * (x_fluxes[i-1][j] - x_fluxes[i][j])) + 
+                (one_dy * (y_fluxes[i][j-1] - y_fluxes[i][j]))
+            );
+
+            fields_update[i][j] = cell_update;
+        }
+    }
+
+    return fields_update;
+}
+
+}
+
+#endif

--- a/src/fvm_2d_cart/scheme/godunov/godunov.h
+++ b/src/fvm_2d_cart/scheme/godunov/godunov.h
@@ -1,0 +1,66 @@
+#ifndef __GODUNOV_H
+#define __GODUNOV_H
+
+#include "../../tensor/tensor.h"
+#include "../../model/model/model.h"
+#include "../../scheme/riemann/riemann/riemann.h"
+#include "../../mesh/mesh/mesh.h"
+#include "../scheme/scheme.h"
+#include "../timestep/timestep.h"
+
+namespace HyperFlow {
+
+class GodunovScheme
+: 
+    public Scheme
+{
+
+public:
+
+    /* Constructor */
+    GodunovScheme();
+
+    /* Constructor with model equations, Riemann solver, time-step */
+    GodunovScheme(const std::shared_ptr<Model>& _model,
+                  const std::shared_ptr<RiemannSolver>& _riemann,
+                  const std::shared_ptr<TimeStep>& _timestep);
+
+    /* Destructor */
+    virtual ~GodunovScheme();
+
+    /* Carry out the Godunov scheme on the provided mesh */
+    virtual Vec3D operator() (const std::shared_ptr<MeshBlock>& mesh_block);
+
+    /* Calculate the time step via the CFL condition */
+    double calculate_time_step(const std::shared_ptr<Mesh>& mesh);
+
+    /* Number of ghost cells associated with the scheme */
+    const static unsigned int ghost_cells;
+
+private:
+
+    /* Calculate the fluxes in the x-direction */
+    Vec3D calculate_fluxes_x(const std::shared_ptr<MeshBlock>& mesh_block);
+
+    /* Calculate the fluxes in the y-direction */
+    Vec3D calculate_fluxes_y(const std::shared_ptr<MeshBlock>& mesh_block);
+
+    /* Calculate the spatial update via the fluxes */
+    Vec3D calculate_spatial_update(const std::shared_ptr<MeshBlock>& mesh_block,
+                                   const Vec3D& x_fluxes,
+                                   const Vec3D& y_fluxes);
+
+    /* Pointer to the model equations */
+    std::shared_ptr<Model> model;
+
+    /* Pointer to the Riemann solver */
+    std::shared_ptr<RiemannSolver> riemann;
+
+    /* Pointer to the time step */
+    std::shared_ptr<TimeStep> timestep;
+
+};
+
+}
+
+#endif

--- a/src/fvm_2d_cart/scheme/riemann/riemann/riemann.cpp
+++ b/src/fvm_2d_cart/scheme/riemann/riemann/riemann.cpp
@@ -1,0 +1,18 @@
+#ifndef __RIEMANN_CPP
+#define __RIEMANN_CPP
+
+#include "riemann.h"
+
+namespace HyperFlow {
+
+/* Constructor */
+RiemannSolver::RiemannSolver()
+{}
+
+/* Destructor */
+RiemannSolver::~RiemannSolver()
+{}
+
+}
+
+#endif

--- a/src/fvm_2d_cart/scheme/riemann/riemann/riemann.h
+++ b/src/fvm_2d_cart/scheme/riemann/riemann/riemann.h
@@ -1,0 +1,31 @@
+#ifndef __RIEMANN_H
+#define __RIEMANN_H
+
+#include "../../../tensor/tensor.h" 
+
+namespace HyperFlow {
+
+/* Allow the Riemann solver to use x or y direction
+ * for flux calculation */
+enum class Direction { x, y };
+
+class RiemannSolver
+{
+
+public:
+    
+    /* Constructor */
+    RiemannSolver();
+
+    /* Destructor */
+    virtual ~RiemannSolver();
+    
+    /* Evaluate Riemann problem */
+    virtual Vec1D operator() (const Vec1D& cons_left,
+                              const Vec1D& cons_right,
+                              const Direction& dir) = 0;
+};
+
+}
+
+#endif

--- a/src/fvm_2d_cart/scheme/riemann/riemann_hllc/riemann_hllc.cpp
+++ b/src/fvm_2d_cart/scheme/riemann/riemann_hllc/riemann_hllc.cpp
@@ -1,0 +1,216 @@
+#ifndef __HLLC_EULER_RIEMANN_SOLVER_CPP
+#define __HLLC_EULER_RIEMANN_SOLVER_CPP
+
+#include "riemann_hllc.h"
+
+namespace HyperFlow {
+
+/* Default Constructor */
+HLLCEulerRiemannSolver::HLLCEulerRiemannSolver()
+{};
+
+/* Constructor from the Euler model */
+HLLCEulerRiemannSolver::HLLCEulerRiemannSolver(
+    const std::shared_ptr<EulerIdealGasModel>& _model
+)
+:
+    model(_model)
+{}
+
+/* Destructor */
+HLLCEulerRiemannSolver::~HLLCEulerRiemannSolver()
+{}
+
+/* Evaluate Riemann problem */
+Vec1D HLLCEulerRiemannSolver::operator() (const Vec1D& cons_left,
+                                          const Vec1D& cons_right,
+                                          const Direction& dir)
+{
+    Vec1D hllc_flux = calc_hllc_flux(cons_left, cons_right, dir);
+    return hllc_flux;
+}
+
+/* Calculate the velocities in the starred region on
+ * either side of the contact discontinuity,
+ * U_L_star and U_R_star
+ * See Toro, 2nd Ed., pg 323, eqn 10.33. */
+Vec1D HLLCEulerRiemannSolver::calc_U_k(const Vec1D& wK, 
+                                       const double S_K,
+                                       const double S_star,
+                                       const Direction& dir) {
+    double dK = wK[0];
+    double uK = wK[1];
+    double vK = wK[2];
+    double pK = wK[3];
+    double EK = model->prim_total_energy(wK);
+
+    Vec1D U_K(4);
+
+    if (dir == Direction::x) {
+        double coef = dK * ((S_K - uK) / (S_K - S_star));
+        U_K[0] = coef;
+        U_K[1] = coef * S_star;
+        U_K[2] = coef * vK;
+        U_K[3] = coef * (EK/dK + (S_star - uK) * (S_star + (pK / (dK * (S_K - uK)))));
+    } else {
+        double coef = dK * ((S_K - vK) / (S_K - S_star));
+        U_K[0] = coef;
+        U_K[1] = coef * uK;
+        U_K[2] = coef * S_star;
+        U_K[3] = coef * (EK/dK + (S_star - vK) * (S_star + (pK / (dK * (S_K - vK)))));
+    }
+    return U_K;
+}
+
+/* Calculate the wave speed S_{*} in the starred region.
+ * See Toro, 2nd Ed., pg 327, eqn 10.58. */
+double HLLCEulerRiemannSolver::calc_S_star(const Vec1D& wL,
+                                           const Vec1D& wR,
+                                           const double S_L,
+                                           const double S_R,
+                                           const Direction& dir) {
+    double dL = wL[0];
+    double uL = wL[1];
+    double vL = wL[2];
+    double pL = wL[3];
+
+    double dR = wR[0];
+    double uR = wR[1];
+    double vR = wR[2];
+    double pR = wR[3];
+
+    double velL = 0.0;
+    double velR = 0.0;
+
+    if (dir == Direction::x) {
+        velL = uL;
+        velR = uR;
+    } else {
+        velL = vL;
+        velR = vR;
+    }
+
+    double num = pR - pL + dL * velL * (S_L - velL) - dR * velR * (S_R - velR);
+    double denom = dL * (S_L - velL) - dR * (S_R - velR);
+    
+    return num/denom;
+}
+
+/* Calculate the wave speed estimates directly.
+ * See Toro, 2nd Ed., pg 324. */
+Vec1D HLLCEulerRiemannSolver::calc_wave_speeds_direct(const Vec1D& wL,
+                                                      const Vec1D& wR,
+                                                      const Direction& dir) {
+    Vec1D waves(2, 0.0);
+    
+    double velL = 0.0;
+    double velR = 0.0;
+
+    if (dir == Direction::x) {
+        velL = wL[1];
+        velR = wR[1];
+    } else {
+        velL = wL[2];
+        velR = wR[2];
+    }
+
+    waves[0] = velL - sqrt(model->get_gamma() * wL[3] / wL[0]);
+    waves[1] = velR + sqrt(model->get_gamma() * wR[3] / wR[0]);
+
+    return waves;
+}
+
+/* Calculate the wave speed estimates directly using
+ * an alternative estimation mechanism. This improves
+ * oscillations in the solution.
+ * See Toro, 2nd Ed., pg 324, eqn 10.38. */
+Vec1D HLLCEulerRiemannSolver::calc_wave_speeds_direct_min_max(const Vec1D& wL,
+                                                              const Vec1D& wR,
+                                                              const Direction& dir) {
+    double a_L = sqrt(model->get_gamma() * wL[3] / wL[0]);
+    double a_R = sqrt(model->get_gamma() * wR[3] / wR[0]);
+
+    Vec1D waves(2, 0.0);
+
+    double velL = 0.0;
+    double velR = 0.0;
+
+    if (dir == Direction::x) {
+        velL = wL[1];
+        velR = wR[1];
+    } else {
+        velL = wL[2];
+        velR = wR[2];
+    }
+
+    waves[0] = std::min(velL - a_L, velR - a_R);
+    waves[1] = std::max(velL + a_L, velR + a_R);
+    
+    return waves;
+}
+
+/* Calculate the fluxes in the starred region. */
+Vec1D HLLCEulerRiemannSolver::calc_F_star(const Vec1D& FK,
+                                          const Vec1D& U_K_star,
+                                          const Vec1D& U_K,
+                                          const double S_K) {
+    Vec1D F_K_star(4);
+    
+    for (unsigned int i=0; i<4; i++) {
+        F_K_star[i] = FK[i] + S_K * (U_K_star[i] - U_K[i]);
+    }
+    
+    return F_K_star;
+}
+
+/* Calculate the Harten-Lax-van Leer-Contact (HLLC) of
+ * Toro to obtain the Euler fluxes.
+ * See Toro, 2nd Ed., pg 323. */
+Vec1D HLLCEulerRiemannSolver::calc_hllc_flux(const Vec1D& U_L,
+                                             const Vec1D& U_R,
+                                             const Direction& dir) {
+    Vec1D wL = model->cons_to_prim(U_L);
+    Vec1D wR = model->cons_to_prim(U_R);
+
+    Vec1D waves = calc_wave_speeds_direct_min_max(wL, wR, dir);
+
+    double S_L = waves[0];
+    double S_R = waves[1];
+
+    Vec1D F_L;
+    Vec1D F_R;
+
+    if (dir == Direction::x) {
+        F_L = model->cons_flux_x(U_L);
+        F_R = model->cons_flux_x(U_R);
+    } else {
+        F_L = model->cons_flux_y(U_L);
+        F_R = model->cons_flux_y(U_R);
+    }
+
+    double S_star = calc_S_star(wL, wR, S_L, S_R, dir);
+    
+    Vec1D U_L_star = calc_U_k(wL, S_L, S_star, dir);
+    Vec1D U_R_star = calc_U_k(wR, S_R, S_star, dir);
+
+    Vec1D F_L_star = calc_F_star(F_L, U_L_star, U_L, S_L);
+    Vec1D F_R_star = calc_F_star(F_R, U_R_star, U_R, S_R);
+
+    if (0.0 <= S_L) {
+        return F_L;
+    } else if (S_L <= 0.0 && 0.0 <= S_star) {
+        return F_L_star;
+    } else if (S_star <= 0.0 && 0.0 <= S_R) {
+        return F_R_star;
+    } else if (0.0 >= S_R) {
+        return F_R;
+    } else {
+        /* Helpful debug information for inconsistent states */
+        std::cout << "HLLC: ERROR - Should not get here." << std::endl;
+        return Vec1D(4, 0.0);
+    }
+}
+
+}
+
+#endif

--- a/src/fvm_2d_cart/scheme/riemann/riemann_hllc/riemann_hllc.h
+++ b/src/fvm_2d_cart/scheme/riemann/riemann_hllc/riemann_hllc.h
@@ -1,0 +1,87 @@
+#ifndef __HLLC_EULER_RIEMANN_SOLVER_H
+#define __HLLC_EULER_RIEMANN_SOLVER_H
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+#include "../riemann/riemann.h"
+#include "../../../model/euler_ideal_gas/euler_ideal_gas.h"
+
+namespace HyperFlow {
+
+class HLLCEulerRiemannSolver
+:
+    public RiemannSolver
+{
+
+    public:
+    
+        /* Constructor */
+        HLLCEulerRiemannSolver(); 
+        
+        /* Construct from the Euler model */
+        HLLCEulerRiemannSolver(const std::shared_ptr<EulerIdealGasModel>& _model);
+        
+        /* Destructor */
+        virtual ~HLLCEulerRiemannSolver();
+        
+        /* Evaluate Riemann problem */ 
+        virtual Vec1D operator() (const Vec1D& cons_left,
+                                  const Vec1D& cons_right,
+                                  const Direction& dir);
+
+    private:
+        
+        /* Calculate the velocities in the starred region on
+         * either side of the contact discontinuity,
+         * U_L_star and U_R_star
+         * See Toro, 2nd Ed., pg 323, eqn 10.33. */
+        Vec1D calc_U_k(const Vec1D& wK, 
+                       const double S_K,
+                       const double S_star,
+                       const Direction& dir);
+        
+        /* Calculate the wave speed S_{*} in the starred region.
+         * See Toro, 2nd Ed., pg 327, eqn 10.58. */
+        double calc_S_star(const Vec1D& wL,
+                           const Vec1D& wR,
+                           const double S_L,
+                           const double S_R,
+                           const Direction& dir);
+        
+        /* Calculate the wave speed estimates directly.
+         * See Toro, 2nd Ed., pg 324. */
+        Vec1D calc_wave_speeds_direct(const Vec1D& wL,
+                                      const Vec1D& wR,
+                                      const Direction& dir);
+        
+        /* Calculate the wave speed estimates directly using
+         * an alternative estimation mechanism. This improves
+         * oscillations in the solution.
+         * See Toro, 2nd Ed., pg 324, eqn 10.38. */
+        Vec1D calc_wave_speeds_direct_min_max(const Vec1D& wL,
+                                              const Vec1D& wR,
+                                              const Direction& dir);
+        
+        /* Calculate the fluxes in the starred region. */
+        Vec1D calc_F_star(const Vec1D& FK,
+                          const Vec1D& U_K_star,
+                          const Vec1D& U_K,
+                          const double S_K);
+        
+        /* Calculate the Harten-Lax-van Leer-Contact (HLLC) of
+         * Toro to obtain the Euler fluxes.
+         * See Toro, 2nd Ed., pg 323. */
+        Vec1D calc_hllc_flux(const Vec1D& U_L,
+                             const Vec1D& U_R,
+                             const Direction& dir);
+
+        /* Pointer to the model equations */
+        std::shared_ptr<EulerIdealGasModel> model;
+        
+};
+
+}
+
+#endif

--- a/src/fvm_2d_cart/scheme/timestep/timestep.cpp
+++ b/src/fvm_2d_cart/scheme/timestep/timestep.cpp
@@ -1,0 +1,79 @@
+#ifndef __TIMESTEP_CPP
+#define __TIMESTEP_CPP
+
+#include "timestep.h"
+
+namespace HyperFlow {
+
+/* Constructor */
+TimeStep::TimeStep()
+{}
+        
+/* Construct the time step with the supplied CFL
+ * and pointer to the model equations */
+TimeStep::TimeStep(const std::shared_ptr<Model>& _model,
+                   const double _cfl)
+:
+    model(_model),
+    cfl(_cfl)
+{
+    steps = 1;
+}
+       
+/* Destructor */
+TimeStep::~TimeStep()
+{}
+
+/* Calculate the timestep from the provided meshblock
+ * and the CFL condition */
+double TimeStep::operator() (const std::shared_ptr<Mesh>& mesh)
+{
+    double final_cfl = 0.0;
+    double dtx = 1e16;
+    double dty = 1e16;
+
+    std::vector<std::shared_ptr<MeshBlock> > mesh_blocks = mesh->get_mesh_blocks();
+
+    for (unsigned int b=0; b<mesh_blocks.size(); b++) {
+        double dx = mesh_blocks[b]->get_dx();
+        double dy = mesh_blocks[b]->get_dy();
+
+        #pragma omp parallel for collapse(2)
+        for (unsigned int i=0; i<mesh_blocks[b]->get_total_x_cells(); i++) {
+            for (unsigned int j=0; j<mesh_blocks[b]->get_total_y_cells(); j++) {
+                Vec1D flow_vals = mesh_blocks[b]->get_flow_values(i, j);
+                Vec1D prim = model->cons_to_prim(flow_vals);
+                
+                double u = prim[1];
+                double v = prim[2];
+                double c = model->prim_speed_of_sound(prim);
+
+                dtx = std::min(dtx, dx / (fabs(u) + c));
+                dty = std::min(dty, dy / (fabs(v) + c));
+            }
+        }
+    }
+
+    /* This is suggested by E. Toro in order to stabilise the
+     * first few iterations, particularly for challenging simulations
+     * such as Riemann shock tube problems */
+    if (steps <= TimeStep::initial_cfl_steps) {
+        final_cfl = TimeStep::initial_cfl_multiplier * cfl;
+    } else {
+        final_cfl = cfl;
+    }
+    steps++;
+
+    return final_cfl * std::min(dtx, dty);
+}
+
+/* Initial CFL multiplier to stabilise
+ * first few iterations */
+double TimeStep::initial_cfl_multiplier = 0.2;
+
+/* Number of steps to restrict CFL for */
+unsigned int TimeStep::initial_cfl_steps = 10;
+
+}
+
+#endif

--- a/src/fvm_2d_cart/scheme/timestep/timestep.h
+++ b/src/fvm_2d_cart/scheme/timestep/timestep.h
@@ -1,0 +1,54 @@
+#ifndef __TIMESTEP_H
+#define __TIMESTEP_H
+
+#include <cmath>
+#include <omp.h>
+
+#include "../../model/model/model.h"
+#include "../../mesh/mesh/mesh.h"
+
+namespace HyperFlow {
+
+class TimeStep {
+
+    public:
+    
+        /* Constructor */
+        TimeStep();
+        
+        /* Construct the time step with the supplied CFL
+         * and pointer to the model equations */
+        TimeStep(const std::shared_ptr<Model>& _model,
+                 const double _cfl);
+       
+        /* Destructor */
+        virtual ~TimeStep();
+        
+        /* Calculate the timestep from the provided meshblock
+         * and the CFL condition */
+        virtual double operator() (const std::shared_ptr<Mesh>& mesh);
+
+    private:
+       
+        /* Initial CFL multiplier to stabilise
+         * first few iterations */
+        static double initial_cfl_multiplier;
+
+        /* Number of steps to restrict CFL for */
+        static unsigned int initial_cfl_steps;
+        
+        /* Pointer to the model equations */
+        std::shared_ptr<Model> model;
+
+        /* CFL value to restrict timestep */
+        double cfl;
+
+        /* Iteration counter for use in determining
+         * whether to apply CFL multiplier */
+        unsigned int steps;
+
+};
+
+}
+
+#endif


### PR DESCRIPTION
**Overview**

This PR adds the ``GodunovScheme``, ``TimeStep``, ``RiemannSolver`` and ``HLLCEulerRiemannSolver`` classes necessary to carry out the first-order upwind scheme of Godunov using the HLLC Riemann solver of Toro et al.